### PR TITLE
Include media object as optional param

### DIFF
--- a/src/Conversions/Actions/PerformConversionAction.php
+++ b/src/Conversions/Actions/PerformConversionAction.php
@@ -19,9 +19,9 @@ class PerformConversionAction
     ) {
         $imageGenerator = ImageGeneratorFactory::forMedia($media);
 
-        $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
+        $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion, $media);
 
-        if (! $copiedOriginalFile) {
+        if (!$copiedOriginalFile) {
             return;
         }
 
@@ -55,7 +55,7 @@ class PerformConversionAction
         string $fileNameWithDirectory,
         string $newFileNameWithoutDirectory
     ): string {
-        $targetFile = pathinfo($fileNameWithDirectory, PATHINFO_DIRNAME).'/'.$newFileNameWithoutDirectory;
+        $targetFile = pathinfo($fileNameWithDirectory, PATHINFO_DIRNAME) . '/' . $newFileNameWithoutDirectory;
 
         rename($fileNameWithDirectory, $targetFile);
 

--- a/src/Conversions/ImageGenerators/Image.php
+++ b/src/Conversions/ImageGenerators/Image.php
@@ -4,10 +4,11 @@ namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Image extends ImageGenerator
 {
-    public function convert(string $path, Conversion $conversion = null): string
+    public function convert(string $path, Conversion $conversion = null, Media $media = null): string
     {
         return $path;
     }

--- a/src/Conversions/ImageGenerators/ImageGenerator.php
+++ b/src/Conversions/ImageGenerators/ImageGenerator.php
@@ -11,11 +11,11 @@ abstract class ImageGenerator
     /*
      * This function should return a path to an image representation of the given file.
      */
-    abstract public function convert(string $file, Conversion $conversion = null): ?string;
+    abstract public function convert(string $file, Conversion $conversion = null, Media $media = null): ?string;
 
     public function canConvert(Media $media): bool
     {
-        if (! $this->requirementsAreInstalled()) {
+        if (!$this->requirementsAreInstalled()) {
             return false;
         }
 

--- a/src/Conversions/ImageGenerators/Pdf.php
+++ b/src/Conversions/ImageGenerators/Pdf.php
@@ -4,12 +4,13 @@ namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Pdf extends ImageGenerator
 {
-    public function convert(string $file, Conversion $conversion = null): string
+    public function convert(string $file, Conversion $conversion = null, Media $media = null): string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.jpg';
 
         $pageNumber = $conversion ? $conversion->getPdfPageNumber() : 1;
 
@@ -20,11 +21,11 @@ class Pdf extends ImageGenerator
 
     public function requirementsAreInstalled(): bool
     {
-        if (! class_exists(\Imagick::class)) {
+        if (!class_exists(\Imagick::class)) {
             return false;
         }
 
-        if (! class_exists(\Spatie\PdfToImage\Pdf::class)) {
+        if (!class_exists(\Spatie\PdfToImage\Pdf::class)) {
             return false;
         }
 

--- a/src/Conversions/ImageGenerators/Svg.php
+++ b/src/Conversions/ImageGenerators/Svg.php
@@ -2,16 +2,17 @@
 
 namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
-use Illuminate\Support\Collection;
 use Imagick;
 use ImagickPixel;
+use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Svg extends ImageGenerator
 {
-    public function convert(string $file, Conversion $conversion = null): string
+    public function convert(string $file, Conversion $conversion = null, Media $media = null): string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.jpg';
 
         $image = new Imagick();
         $image->readImage($file);

--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -2,15 +2,16 @@
 
 namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
-use FFMpeg\Coordinate\TimeCode;
 use FFMpeg\FFMpeg;
-use FFMpeg\Media\Video as FFMpegVideo;
+use FFMpeg\Coordinate\TimeCode;
 use Illuminate\Support\Collection;
+use FFMpeg\Media\Video as FFMpegVideo;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Video extends ImageGenerator
 {
-    public function convert(string $file, Conversion $conversion = null): ?string
+    public function convert(string $file, Conversion $conversion = null, Media $media = null): ?string
     {
         $ffmpeg = FFMpeg::create([
             'ffmpeg.binaries' => config('media-library.ffmpeg_path'),
@@ -19,7 +20,7 @@ class Video extends ImageGenerator
 
         $video = $ffmpeg->open($file);
 
-        if (! ($video instanceof FFMpegVideo)) {
+        if (!($video instanceof FFMpegVideo)) {
             return null;
         }
 
@@ -28,7 +29,7 @@ class Video extends ImageGenerator
         $seconds = $conversion ? $conversion->getExtractVideoFrameAtSecond() : 0;
         $seconds = $duration <= $seconds ? 0 : $seconds;
 
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.jpg';
 
         $frame = $video->frame(TimeCode::fromSeconds($seconds));
         $frame->save($imageFile);

--- a/src/Conversions/ImageGenerators/Webp.php
+++ b/src/Conversions/ImageGenerators/Webp.php
@@ -4,12 +4,13 @@ namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Webp extends ImageGenerator
 {
-    public function convert(string $file, Conversion $conversion = null): string
+    public function convert(string $file, Conversion $conversion = null, Media $media = null): string
     {
-        $pathToImageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.png';
+        $pathToImageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.png';
 
         $image = imagecreatefromwebp($file);
 
@@ -22,15 +23,15 @@ class Webp extends ImageGenerator
 
     public function requirementsAreInstalled(): bool
     {
-        if (! function_exists('imagecreatefromwebp')) {
+        if (!function_exists('imagecreatefromwebp')) {
             return false;
         }
 
-        if (! function_exists('imagepng')) {
+        if (!function_exists('imagepng')) {
             return false;
         }
 
-        if (! function_exists('imagedestroy')) {
+        if (!function_exists('imagedestroy')) {
             return false;
         }
 


### PR DESCRIPTION
Adding the media object as a parameter to the convert method.
- This allows us to utilize the media objects parameters to leverage how the media should be processed from a custom image manipulator.

### Current TODOs
- **Explanation:** Rather than forcing the media object to be included in the convert method, write a way for it to be an optional parameter.
- **Idea:** Create a new Conversion method that allows us to include the media object for only specified conversions. For example how the withResponsiveImages() (or any other options that can be conversion specific) method is defined.